### PR TITLE
added test with large graph

### DIFF
--- a/test/layout.js
+++ b/test/layout.js
@@ -267,6 +267,31 @@ test('it removes removed nodes', function (t) {
   t.end();
 });
 
+test('it handles large graphs', function (t) {
+  var graph = createGraph();
+  var layout = createLayout(graph);
+
+  var count = 60000;
+  
+  var i = count;
+  while (i--) {
+    graph.addNode(i);
+  }
+
+  // link each node to 2 other random nodes
+  var i = count;
+  while (i--) {
+    graph.addLink(i, Math.ceil(Math.random() * count));
+    graph.addLink(i, Math.ceil(Math.random() * count));
+  }
+
+  layout.step();
+
+  t.ok(layout.simulator.bodies.length !== 0, 'Bodies in the simulator');
+  t.end();
+});
+
+
 function positionChanged(pos1, pos2) {
   return (pos1.x !== pos2.x) || (pos1.y !== pos2.y);
 }


### PR DESCRIPTION
This test hangs. I tried reducing the number of nodes until it passed and found that at 6845 nodes it will pass. That magic number was consistent on both my Windows machine and my Linux machine.

I originally reported this [issue](https://github.com/anvaka/ngraph.quadtreebh/issues/2) on ngraph.quadtreebh because the hange occurs within that module. But as you discovered, when testing in isolation on that module there seems to be no problem. The problem occurs when quadtreebh is used through forcelayout.
