### PR TITLE
Generate correct bounds when all points have negative coordinate

### DIFF
--- a/lib/codeGenerators/generateBounds.js
+++ b/lib/codeGenerators/generateBounds.js
@@ -49,8 +49,8 @@ function generateBoundsFunctionBody(dimension) {
     var i = bodies.length;
     if (i === 0) return; // No bodies - no borders.
 
-    ${pattern('var max_{var} = Number.MIN_VALUE;', {indent: 4})}
-    ${pattern('var min_{var} = Number.MAX_VALUE;', {indent: 4})}
+    ${pattern('var max_{var} = -Infinity;', {indent: 4})}
+    ${pattern('var min_{var} = Infinity;', {indent: 4})}
 
     while(i--) {
       // this is O(n), it could be done faster with quadtree, if we check the root node bounds


### PR DESCRIPTION
This can happen if the user pins some nodes far enough from the origin.