### PR TITLE
Add EventedType to createLayout return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 declare module "ngraph.forcelayout" {
   import { Graph, NodeId, LinkId, Node, Link } from "ngraph.graph";
+  import { EventedType } from "ngraph.events";
 
   export type ForceFunction = (iterationNumber: number) => void;
 
@@ -369,5 +370,5 @@ declare module "ngraph.forcelayout" {
   export default function createLayout<T extends Graph>(
     graph: T,
     physicsSettings?: Partial<PhysicsSettings>
-  ): Layout<T>;
+  ): Layout<T> & EventedType;
 }

--- a/index.v43.d.ts
+++ b/index.v43.d.ts
@@ -1,5 +1,6 @@
 declare module "ngraph.forcelayout" {
   import { Graph, NodeId, LinkId, Node, Link } from "ngraph.graph";
+  import { EventedType } from "ngraph.events";
 
   export type ForceFunction = (iterationNumber: number) => void;
 
@@ -364,5 +365,5 @@ declare module "ngraph.forcelayout" {
   export default function createLayout<T extends Graph>(
     graph: T,
     physicsSettings?: Partial<PhysicsSettings>
-  ): Layout<T>;
+  ): Layout<T> & EventedType;
 }


### PR DESCRIPTION
Considering that the API uses ngraph.events, this pull request adds EventedType to createLayout return in .d.ts files, so that these events may be used in typescript projects.